### PR TITLE
Feat: API 초기셋팅

### DIFF
--- a/Duckmelang/Duckmelang/Info.plist
+++ b/Duckmelang/Duckmelang/Info.plist
@@ -19,6 +19,11 @@
 		<string>Pretendard-SemiBold.otf</string>
 		<string>Pretendard-Thin.otf</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Duckmelang/Duckmelang/MyAccompany/ViewControllers/MyAccompanyViewController.swift
+++ b/Duckmelang/Duckmelang/MyAccompany/ViewControllers/MyAccompanyViewController.swift
@@ -6,12 +6,15 @@
 //
 
 import UIKit
+import Moya
 
 class MyAccompanyViewController: UIViewController {
+    private let provider = MoyaProvider<AllEndpoint>(plugins: [NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))])
+    
     var selectedTag: Int = 0
     
     let data1 = MyAccompanyModel.dummy()
-    let data2 = PostModel.dummy1()
+    var data2 = PostModel.dummy1()
     let data3 = PostModel.dummy2()
     
     override func viewDidLoad() {
@@ -79,10 +82,12 @@ class MyAccompanyViewController: UIViewController {
             myAccompanyView.myAccompanyTableView.isHidden = true
             myAccompanyView.scrapTableView.isHidden = false
             myAccompanyView.myPostsTableView.isHidden = true
+            getBookmarksAPI()
         } else {
             myAccompanyView.myAccompanyTableView.isHidden = true
             myAccompanyView.scrapTableView.isHidden = true
             myAccompanyView.myPostsTableView.isHidden = false
+            getMyPostsAPI()
         }
         
         let width = myAccompanyView.segmentedControl.frame.width / CGFloat(myAccompanyView.segmentedControl.numberOfSegments)
@@ -90,6 +95,31 @@ class MyAccompanyViewController: UIViewController {
                 
         UIView.animate(withDuration: 0.2) {
             self.myAccompanyView.underLineView.frame.origin.x = xPosition
+        }
+    }
+    
+    private func getBookmarksAPI() {
+        provider.request(.getMyPosts(memberId: 1, page: 0)) { result in
+            switch result {
+            case .success(let response):
+                let response = try? response.map(ApiResponse<PostResponse>.self)
+                guard let result = response?.result?.postList else { return }
+                print("스크랩: \(result)")
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    private func getMyPostsAPI() {
+        provider.request(.getMyPosts(memberId: 1, page: 0)) { result in
+            switch result {
+            case .success(let response):
+                let response = try? response.map(ApiResponse<PostResponse>.self)
+                guard let result = response?.result?.postList else { return }
+                print("내 게시물: \(result)")
+            case .failure(let error):
+                print(error)
+            }
         }
     }
     

--- a/Duckmelang/Duckmelang/Network/CommonResponse.swift
+++ b/Duckmelang/Duckmelang/Network/CommonResponse.swift
@@ -1,0 +1,32 @@
+//
+//  CommonReponse.swift
+//  Duckmelang
+//
+//  Created by 주민영 on 1/29/25.
+//
+
+import Foundation
+
+// 최상위 응답 모델
+public struct ApiResponse<T: Decodable>: Decodable {
+    public let isSuccess: Bool
+    public let code: String
+    public let message: String
+    public let result: T?
+}
+
+/// API 사용법
+//private let provider = MoyaProvider<AllEndpoint>(plugins: [NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))])
+//
+//private func getMyPostsAPI() {
+//    provider.request(.getMyPosts(memberId: 1, page: 0)) { result in
+//        switch result {
+//        case .success(let response):
+//            let response = try? response.map(ApiResponse<MyPostResponse>.self)
+//            guard let result = response?.result?.postList else { return }
+//            print(result)
+//        case .failure(let error):
+//            print(error)
+//        }
+//    }
+//}

--- a/Duckmelang/Duckmelang/Network/Domain.swift
+++ b/Duckmelang/Duckmelang/Network/Domain.swift
@@ -1,0 +1,18 @@
+//
+//  Domain.swift
+//  Duckmelang
+//
+//  Created by 주민영 on 1/28/25.
+//
+
+import UIKit
+
+public struct API {
+    public static let baseURL = "http://13.125.217.231:8080"
+    public static let reviewURL = "\(baseURL)/reviews"
+    public static let requestURL = "\(baseURL)/requests"
+    public static let postURL = "\(baseURL)/posts"
+    public static let memberURL = "\(baseURL)/members"
+    public static let mypageURL = "\(baseURL)/mypage"
+    public static let profileURL = "\(baseURL)/profile"
+}

--- a/Duckmelang/Duckmelang/Network/Endpoint.swift
+++ b/Duckmelang/Duckmelang/Network/Endpoint.swift
@@ -1,0 +1,66 @@
+//
+//  Endpoint.swift
+//  Duckmelang
+//
+//  Created by 주민영 on 1/28/25.
+//
+
+import UIKit
+import Moya
+
+public enum AllEndpoint {
+    case getMyPosts(memberId: Int, page: Int)
+    case getBookmarks(memberId: Int, page: Int)
+    case getProfileImage(memberId: Int, page: Int)
+}
+
+extension AllEndpoint: TargetType {
+    public var baseURL: URL {
+        switch self {
+        case .getMyPosts(_, _):
+            guard let url = URL(string: API.postURL) else {
+                fatalError("baseURL 오류")
+            }
+            return url
+        case .getBookmarks(_, _), .getProfileImage(_, _):
+            guard let url = URL(string: API.baseURL) else {
+                fatalError("baseURL 오류")
+            }
+            return url
+        }
+    }
+    
+    public var path: String {
+        switch self {
+        case .getMyPosts(_, _):
+            return "/my"
+        case .getBookmarks(let memberId, _):
+            return "/bookmarks/\(memberId)"
+        case .getProfileImage(_, _):
+            return "/mypage/profile/image/"
+        }
+    }
+    
+    public var method: Moya.Method {
+        switch self {
+        default:
+            return .get
+        }
+    }
+    
+    public var task: Moya.Task {
+        switch self {
+        case .getMyPosts(let memberId, let page), .getProfileImage(let memberId, let page):
+            return .requestParameters(parameters: ["memberId": memberId, "page": page], encoding: URLEncoding.queryString)
+        case .getBookmarks(_, let page):
+            return .requestParameters(parameters: ["page": page], encoding: URLEncoding.queryString)
+        }
+    }
+    
+    public var headers: [String : String]? {
+        switch self {
+        default :
+            return ["Content-Type": "application/json"]
+        }
+    }
+}

--- a/Duckmelang/Duckmelang/Network/Response.swift
+++ b/Duckmelang/Duckmelang/Network/Response.swift
@@ -1,0 +1,27 @@
+//
+//  Response.swift
+//  Duckmelang
+//
+//  Created by 주민영 on 1/28/25.
+//
+
+import Foundation
+
+// 게시글 정보를 담는 구조체
+public struct PostDTO: Codable {
+    public let postId: Int
+    public let title: String
+    public let category: String
+    public let date: String
+    public let nickname: String
+    public let createdAt: String
+}
+
+public struct PostResponse: Codable {
+    let postList: [PostDTO]
+    let listSize: Int
+    let totalPage: Int
+    let totalElements: Int
+    let isFirst: Bool
+    let isLast: Bool
+}


### PR DESCRIPTION
## 개요
API 초기셋팅

## PR 유형
어떤 변경 사항이 있나요?

- [x] API 호출을 위한 파일 생성
- [x] 도메인 설정
- [x] CommonResponse 생성
- [x] `CommonResponse.swift` 파일에 아래와 같은 예제코드를 작성해놓았으니 참고해서 사용하시면 될 것같습니다.
```swift
// API 사용법
// API 받아오기 전에 Network/Endpoint.swift, Response.swift 설정하기!!
private let provider = MoyaProvider<AllEndpoint>(plugins: [NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))])

private func getMyPostsAPI() {
    provider.request(.getMyPosts(memberId: 1, page: 0)) { result in
        switch result {
        case .success(let response):
            let response = try? response.map(ApiResponse<MyPostResponse>.self)
            guard let result = response?.result?.postList else { return }
            print(result)
        case .failure(let error):
            print(error)
        }
    }
}
```
*멤버아이디와 페이지네이션은 아직 구현이 되지 않아 더미데이터 속 한 멤버아이디의 데이터를 가져오는 식으로, 페이지네이션은 적용하지 않고 무조건 0번째 페이지를 가져오는 방식으로 구현했습니다.

- [x] 테스트 및 예제로 스크랩 및 내 게시물 불러오기 API를 호출하는 함수를 만들어서 적용해놓았습니다. 필요하시다면 `MyAccompanyViewController.swift `파일도 참고하시면 좋을 것같습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
