### PR TITLE
Feat: 게시글, 피드관리 api 연결

### DIFF
--- a/Duckmelang/Duckmelang.xcodeproj/xcuserdata/nauvy__.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Duckmelang/Duckmelang.xcodeproj/xcuserdata/nauvy__.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -46,8 +46,8 @@
             filePath = "Duckmelang/MyPage/ViewController/PostDetailViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "10"
-            endingLineNumber = "10"
+            startingLineNumber = "11"
+            endingLineNumber = "11"
             landmarkName = "PostProgressState"
             landmarkType = "13">
          </BreakpointContent>

--- a/Duckmelang/Duckmelang/Cells/FeedManagementCell.swift
+++ b/Duckmelang/Duckmelang/Cells/FeedManagementCell.swift
@@ -135,4 +135,22 @@ class FeedManagementCell: UITableViewCell {
             for: .normal
         )
     }
+    
+    public func configure(model: PostDTO) {
+        if let postImageUrl = URL(string: model.postImageUrl) {
+            self.postImage.kf.setImage(with: postImageUrl, placeholder: UIImage(named: "defaultPostImage"))
+        }
+        
+        self.postTitle.text = model.title
+        self.EventTypeDate.text = "\(model.category) | \(model.date)"
+        
+        if let userImageUrl = URL(string: model.latestPublicMemberProfileImage) {
+            self.userImage.kf.setImage(with: userImageUrl, placeholder: UIImage(named: "defaultUserImage"))
+        }
+        
+        self.userName.text = model.nickname
+        
+        print("📌 [DEBUG] PostCell configure() 호출됨")
+        print("📌 postId: \(model.postId), title: \(model.title)")
+    }
 }

--- a/Duckmelang/Duckmelang/Cells/PostFilterCell.swift
+++ b/Duckmelang/Duckmelang/Cells/PostFilterCell.swift
@@ -90,7 +90,9 @@ class AgeSelectionCell: UITableViewCell {
         $0.upperValue = 28
     }
     
-    private let ageLabel = Label(text: "만 18 ~ 28세", font: .ptdSemiBoldFont(ofSize: 22), color: .grey800)
+    private let ageLabel = Label(text: "만 18 ~ 28세", font: .ptdSemiBoldFont(ofSize: 22), color: .grey800).then {
+        $0.textAlignment = .left
+    }
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -100,6 +102,7 @@ class AgeSelectionCell: UITableViewCell {
         
         ageLabel.snp.makeConstraints {
             $0.top.leading.equalToSuperview().inset(16)
+            $0.width.greaterThanOrEqualTo(200)
         }
         
         rangeSlider.snp.makeConstraints {

--- a/Duckmelang/Duckmelang/MyPage/View/MyPageTopView.swift
+++ b/Duckmelang/Duckmelang/MyPage/View/MyPageTopView.swift
@@ -99,7 +99,7 @@ class MyPageTopView: UIView {
     //UI 업데이트 함수 추가
     func updateProfile(with data: ProfileData) {
         nickname.text = data.nickname
-        gender.text = data.gender
+        gender.text = data.localizedGender
         age.text = "\(data.age)"
         
         //Kingfisher로 이미지 로딩 (URL이 유효한 경우만)

--- a/Duckmelang/Duckmelang/MyPage/View/PostDetailView.swift
+++ b/Duckmelang/Duckmelang/MyPage/View/PostDetailView.swift
@@ -79,7 +79,7 @@ class PostDetailView: UIView {
     }
     
     // **UI 업데이트 함수**
-    private func updateUI(with data: MyPostDetailResponse) {
+    func updateUI(with data: MyPostDetailResponse) {
         // 이미지 로드 (첫 번째 이미지)
         if let firstImageUrlString = data.postImageURL.first,
            let imageUrl = URL(string: firstImageUrlString) {
@@ -101,7 +101,7 @@ class PostDetailView: UIView {
     }
     
     // **이미지 로드 함수 (비동기)**
-    private func loadImage(from url: URL, into scrollView: UIScrollView) {
+    func loadImage(from url: URL, into scrollView: UIScrollView) {
         DispatchQueue.global().async {
             if let data = try? Data(contentsOf: url), let image = UIImage(data: data) {
                 DispatchQueue.main.async {

--- a/Duckmelang/Duckmelang/MyPage/View/PostDetailView.swift
+++ b/Duckmelang/Duckmelang/MyPage/View/PostDetailView.swift
@@ -76,7 +76,43 @@ class PostDetailView: UIView {
         postDetailBottomView.snp.makeConstraints{
             $0.top.equalTo(postDetailTopView.profileInfo.snp.bottom).offset(16)
         }
+    }
+    
+    // **UI 업데이트 함수**
+    private func updateUI(with data: MyPostDetailResponse) {
+        // 이미지 로드 (첫 번째 이미지)
+        if let firstImageUrlString = data.postImageURL.first,
+           let imageUrl = URL(string: firstImageUrlString) {
+            loadImage(from: imageUrl, into: postDetailTopView.imageView)
+        }
         
+        // 상단 프로필 정보 업데이트
+        postDetailTopView.nickname.text = data.nickname
+        postDetailTopView.gender.text = (data.gender == "MALE") ? "남성" : "여성"
+        postDetailTopView.age.text = "\(data.age)세"
+        
+        // 하단 게시글 정보 업데이트
+        postDetailBottomView.title1.text = data.title
+        postDetailBottomView.body.text = data.content
+        postDetailBottomView.info.text = "스크랩 \(data.bookmarkCount) | 채팅 \(data.viewCount) | 조회 \(data.viewCount)"
+        
+        // 동행 정보 TableView에 데이터 리로드 (예시)
+        // postDetailBottomView.tableView.reloadData()
+    }
+    
+    // **이미지 로드 함수 (비동기)**
+    private func loadImage(from url: URL, into scrollView: UIScrollView) {
+        DispatchQueue.global().async {
+            if let data = try? Data(contentsOf: url), let image = UIImage(data: data) {
+                DispatchQueue.main.async {
+                    let imageView = UIImageView(image: image)
+                    imageView.contentMode = .scaleAspectFill
+                    imageView.clipsToBounds = true
+                    imageView.frame = scrollView.bounds
+                    scrollView.addSubview(imageView)
+                }
+            }
+        }
     }
 }
 
@@ -95,7 +131,7 @@ class PostDetailTopView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private lazy var imageView = UIScrollView().then {
+    lazy var imageView = UIScrollView().then {
         $0.backgroundColor = .grey200
         $0.isPagingEnabled = true
     }
@@ -111,11 +147,11 @@ class PostDetailTopView: UIView {
     
     lazy var nickname = Label(text: "닉네임", font: .ptdSemiBoldFont(ofSize: 14), color: .black)
     
-    private lazy var gender = Label(text: "여성", font: .ptdRegularFont(ofSize: 13), color: .grey600)
+    lazy var gender = Label(text: "여성", font: .ptdRegularFont(ofSize: 13), color: .grey600)
     
     private lazy var line = Label(text: "ㅣ", font: .ptdRegularFont(ofSize: 13), color: .grey400)
     
-    private lazy var age = Label(text: "나이", font: .ptdRegularFont(ofSize: 13), color: .grey600)
+    lazy var age = Label(text: "나이", font: .ptdRegularFont(ofSize: 13), color: .grey600)
     
     lazy var progressBtn = UIButton().then {
         var config = UIButton.Configuration.plain()
@@ -247,11 +283,11 @@ class PostDetailBottomView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private lazy var title1 = Label(text: "게시글 제목", font: .ptdSemiBoldFont(ofSize: 17), color: .grey900)
+    lazy var title1 = Label(text: "게시글 제목", font: .ptdSemiBoldFont(ofSize: 17), color: .grey900)
     
-    private lazy var body = Label(text: "본문 \n", font: .ptdRegularFont(ofSize: 15), color: .grey900)
+    lazy var body = Label(text: "본문 \n", font: .ptdRegularFont(ofSize: 15), color: .grey900)
     
-    private lazy var info = Label(text: "스크랩 0      | 채팅 0      | 조회 0 ", font: .ptdRegularFont(ofSize: 12), color: .grey500)
+    lazy var info = Label(text: "스크랩 0      | 채팅 0      | 조회 0 ", font: .ptdRegularFont(ofSize: 12), color: .grey500)
     private lazy var textStack = Stack(axis: .vertical, spacing: 8)
     
     private lazy var title2 = Label(text: "동행 정보", font: .ptdSemiBoldFont(ofSize: 17), color: .grey900)
@@ -286,4 +322,6 @@ class PostDetailBottomView: UIView {
             $0.height.equalTo(500)//수정예정
         }
     }
+    
+    
 }

--- a/Duckmelang/Duckmelang/MyPage/View/Profile/ProfileView.swift
+++ b/Duckmelang/Duckmelang/MyPage/View/Profile/ProfileView.swift
@@ -193,7 +193,7 @@ class ProfileTopView: UIView {
     
     func updateProfile(with data: ProfileData) {
         nickname.text = data.nickname
-        gender.text = data.gender
+        gender.text = data.localizedGender
         age.text = "\(data.age)"
         
         postCount.text = "\(data.postCount)"

--- a/Duckmelang/Duckmelang/MyPage/ViewController/Profile/FeedManagementViewController.swift
+++ b/Duckmelang/Duckmelang/MyPage/ViewController/Profile/FeedManagementViewController.swift
@@ -89,26 +89,42 @@ class FeedManagementViewController: UIViewController {
     
     // 내 게시글 가져오기
     private func fetchMyPosts() {
-        provider.request(.getMyPosts(memberId: 1)) { result in
+        provider.request(.getMyPosts(memberId: 1, page: 1)) { result in
             switch result {
             case .success(let response):
+                print("📌 [DEBUG] HTTP 상태 코드: \(response.statusCode)")  // 상태 코드 출력
+                print("📌 [DEBUG] 응답 헤더: \(response.response?.allHeaderFields ?? [:])")  // 응답 헤더 출력
+                
                 do {
                     let decodedResponse = try response.map(ApiResponse<PostResponse>.self)
-                    //디버깅용 데이터 출력 (서버 응답 확인)
-                    print("📌 [DEBUG] 서버 응답 데이터:")
-                    print(decodedResponse)
+                    
+                    // 📌 성공 시 응답 데이터 출력
+                    print("✅ [DEBUG] 성공적으로 디코딩됨: \(decodedResponse)")
+
                     // `postList`가 `nil`이면 빈 배열을 할당하여 오류 방지
                     let postList = decodedResponse.result?.postList ?? []
-                    
+
                     DispatchQueue.main.async {
                         self.posts = postList
-                        self.feedManagementView.postView.reloadData() // 테이블뷰 갱신
+                        self.feedManagementView.postView.reloadData()  // 테이블뷰 갱신
                     }
                 } catch {
-                    print("JSON 디코딩 오류: \(error.localizedDescription)")
+                    // ❌ JSON 디코딩 오류 세부 정보 출력
+                    print("❌ [DEBUG] JSON 디코딩 오류: \(error.localizedDescription)")
+                    if let responseString = String(data: response.data, encoding: .utf8) {
+                        print("📌 [DEBUG] 응답 바디: \(responseString)")  // 응답 바디 확인
+                    }
                 }
+
             case .failure(let error):
-                print("게시글 불러오기 실패: \(error.localizedDescription)")
+                // ❌ 요청 실패 시 오류 메시지와 기타 정보 출력
+                print("❌ [DEBUG] 요청 실패: \(error.localizedDescription)")
+                if let response = error.response {
+                    print("📌 [DEBUG] 상태 코드: \(response.statusCode)")
+                    if let responseString = String(data: response.data, encoding: .utf8) {
+                        print("📌 [DEBUG] 응답 바디: \(responseString)")
+                    }
+                }
             }
         }
     }

--- a/Duckmelang/Duckmelang/MyPage/ViewController/Profile/FeedManagementViewController.swift
+++ b/Duckmelang/Duckmelang/MyPage/ViewController/Profile/FeedManagementViewController.swift
@@ -6,12 +6,17 @@
 //
 
 import UIKit
+import Moya
 
 class FeedManagementViewController: UIViewController {
     
     var data = FeedManagementModel.dummy()
     
     var selectedIndices: Set<IndexPath> = [] // 선택된 셀의 indexPath를 저장
+    
+    private let provider = MoyaProvider<MyPageAPI>(plugins: [NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))])
+
+    private var posts: [PostDTO] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,6 +27,7 @@ class FeedManagementViewController: UIViewController {
         
         setupDelegate()
         setupAction()
+        fetchMyPosts()
     }
     
     private lazy var feedManagementView = FeedManagementView()
@@ -80,6 +86,32 @@ class FeedManagementViewController: UIViewController {
         feedManagementView.finishBtn.addTarget(self, action: #selector(finishBtnDidTap), for: .touchUpInside)
         feedManagementView.deleteBtn.addTarget(self, action: #selector(deleteBtnDidTap), for: .touchUpInside)
     }
+    
+    // 내 게시글 가져오기
+    private func fetchMyPosts() {
+        provider.request(.getMyPosts(memberId: 1)) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    let decodedResponse = try response.map(ApiResponse<PostResponse>.self)
+                    //디버깅용 데이터 출력 (서버 응답 확인)
+                    print("📌 [DEBUG] 서버 응답 데이터:")
+                    print(decodedResponse)
+                    // `postList`가 `nil`이면 빈 배열을 할당하여 오류 방지
+                    let postList = decodedResponse.result?.postList ?? []
+                    
+                    DispatchQueue.main.async {
+                        self.posts = postList
+                        self.feedManagementView.postView.reloadData() // 테이블뷰 갱신
+                    }
+                } catch {
+                    print("JSON 디코딩 오류: \(error.localizedDescription)")
+                }
+            case .failure(let error):
+                print("게시글 불러오기 실패: \(error.localizedDescription)")
+            }
+        }
+    }
 }
 
 extension FeedManagementViewController: UITableViewDataSource, UITableViewDelegate {
@@ -88,10 +120,20 @@ extension FeedManagementViewController: UITableViewDataSource, UITableViewDelega
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard !posts.isEmpty else { return UITableViewCell() } //데이터 없을 때 기본 셀 반환
+            
         guard let cell = tableView.dequeueReusableCell(withIdentifier: FeedManagementCell.identifier, for: indexPath) as? FeedManagementCell else {
             return UITableViewCell()
         }
-        cell.configure(model: data[indexPath.row])
+        
+        //posts 배열에서 해당 인덱스의 데이터를 가져와 전달
+        let post = posts[indexPath.row]
+        cell.configure(model: post)
+        
+        //디버깅용 데이터 출력
+        print("📌 [DEBUG] configure()에 전달되는 Post 데이터:")
+        print("📌 postId: \(post.postId), title: \(post.title), category: \(post.category)")
+        print("📌 postImageUrl: \(post.postImageUrl), latestProfileImage: \(post.latestPublicMemberProfileImage)")
         
         // 셀이 선택된 상태인지 확인
         if selectedIndices.contains(indexPath) {

--- a/Duckmelang/Duckmelang/MyPage/ViewController/Profile/ProfileViewController.swift
+++ b/Duckmelang/Duckmelang/MyPage/ViewController/Profile/ProfileViewController.swift
@@ -50,7 +50,7 @@ class ProfileViewController: UIViewController{
     
     // 내 게시글 가져오기
     private func fetchMyPosts() {
-        provider.request(.getMyPosts(memberId: 1)) { result in
+        provider.request(.getMyPosts(memberId: 1, page: 1)) { result in
             switch result {
             case .success(let response):
                 do {

--- a/Duckmelang/Duckmelang/Network/APIs/MyPageAPI.swift
+++ b/Duckmelang/Duckmelang/Network/APIs/MyPageAPI.swift
@@ -18,7 +18,7 @@ public enum MyPageAPI {
     case getProfileImage(memberId: Int, page: Int)
     case getProfile(memberId: Int)
     case patchProfile(memberId: Int, profileData: EditProfileRequest)
-    case getMyPosts(memberId: Int)
+    case getMyPosts(memberId: Int, page: Int)
     case getReviews(memberId: Int)
     case getMyPostDetail(postId: Int)
 }
@@ -87,8 +87,10 @@ extension MyPageAPI: TargetType {
                 bodyEncoding: JSONEncoding.default,
                 urlParameters: ["memberId": memberId] // Query Parameter로 전송
             )
-        case .getReviews(memberId: let memberId), .getMyPosts(memberId: let memberId):
+        case .getReviews(memberId: let memberId):
             return .requestParameters(parameters: ["memberId": memberId], encoding: URLEncoding.queryString)
+        case .getMyPosts(let memberId, let page):
+            return .requestParameters(parameters: ["memberId": memberId, "page": page], encoding: URLEncoding.queryString)
         case .getMyPostDetail(postId: _):
             return .requestPlain
         }

--- a/Duckmelang/Duckmelang/Network/APIs/MyPageAPI.swift
+++ b/Duckmelang/Duckmelang/Network/APIs/MyPageAPI.swift
@@ -20,6 +20,7 @@ public enum MyPageAPI {
     case patchProfile(memberId: Int, profileData: EditProfileRequest)
     case getMyPosts(memberId: Int)
     case getReviews(memberId: Int)
+    case getMyPostDetail(postId: Int)
 }
 
 extension MyPageAPI: TargetType {
@@ -27,6 +28,11 @@ extension MyPageAPI: TargetType {
     // 모두 같은 baseURL을 사용한다면 default로 지정하기
     public var baseURL: URL {
         switch self {
+        case.getMyPostDetail:
+            guard let url = URL(string: API.postURL) else {
+                fatalError("mypageURL 오류")
+            }
+            return url
         default:
             guard let url = URL(string: API.mypageURL) else {
                 fatalError("mypageURL 오류")
@@ -48,6 +54,8 @@ extension MyPageAPI: TargetType {
             return "/posts"
         case .getReviews:
             return "/reviews"
+        case .getMyPostDetail(postId: let postId):
+            return "/\(postId)"
         }
     }
     
@@ -81,6 +89,8 @@ extension MyPageAPI: TargetType {
             )
         case .getReviews(memberId: let memberId), .getMyPosts(memberId: let memberId):
             return .requestParameters(parameters: ["memberId": memberId], encoding: URLEncoding.queryString)
+        case .getMyPostDetail(postId: _):
+            return .requestPlain
         }
     }
     

--- a/Duckmelang/Duckmelang/Network/Responses/MyPageResponse.swift
+++ b/Duckmelang/Duckmelang/Network/Responses/MyPageResponse.swift
@@ -40,3 +40,22 @@ public struct ReviewResponse: Codable {
     let average: Double
     let myReviewList: [myReviewDTO] //리뷰 목록
 }
+
+struct MyPostDetailResponse: Codable {
+    let nickname: String
+    let age: Int
+    let gender: String
+    let averageScore: Double
+    let bookmarkCount: Int
+    let viewCount: Int
+    let title: String
+    let content: String
+    let wanted: Int
+    let idol: [String]
+    let category: String
+    let date: String
+    let createdAt: String
+    let postImageURL: [String]
+    let latestPublicMemberProfileImage: String
+}
+

--- a/Duckmelang/Duckmelang/Network/Responses/MyPageResponse.swift
+++ b/Duckmelang/Duckmelang/Network/Responses/MyPageResponse.swift
@@ -16,9 +16,9 @@ public struct ProfileData: Codable {
     let postCount: Int
     let succeedApplicationCount: Int
     
-    /*var localizedGender: String {
+    var localizedGender: String {
         return gender.lowercased() == "male" ? "남성" : "여성"
-    }*/
+    }
 }
 
 // 리뷰 데이터 구조체
@@ -30,9 +30,9 @@ public struct myReviewDTO: Codable {
     let content: String
     let score: Int
     
-    /*var localizedGender: String {
+    var localizedGender: String {
         return gender.lowercased() == "male" ? "남성" : "여성"
-    }*/
+    }
 }
 
 // API 응답 구조체 (리뷰 리스트 포함)


### PR DESCRIPTION
## 개요


## PR 유형
어떤 변경 사항이 있나요?

- [x] 게시글 api 연결
- [x] 피드관리 api 연결

데이터 없어서 안보입니다.

<img width="499" alt="스크린샷 2025-02-09 오후 5 07 54" src="https://github.com/user-attachments/assets/48bef1d7-2def-42bc-a53e-bc5fd9012266" />
![Simulator Screenshot - iPhone 16 Pro - 2025-02-09 at 17 07 28](https://github.com/user-attachments/assets/5f97f90c-ba34-424d-9127-ddc9e65e848b)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-09 at 17 18 40](https://github.com/user-attachments/assets/ce2ac352-068d-4df6-9325-14ebebbf71ea)
Moya_Logger: [2/9/25, 5:17 PM] Response Body: {"isSuccess":true,"code":"COMMON200","message":"성공입니다.","result":{"postList":[],"listSize":0,"totalPage":0,"totalElements":0,"isFirst":false,"isLast":true}}
📌 [DEBUG] HTTP 상태 코드: 200
📌 [DEBUG] 응답 헤더: [AnyHashable("Content-Type"): application/json, AnyHashable("Vary"): Origin, Access-Control-Request-Method, Access-Control-Request-Headers, AnyHashable("X-Content-Type-Options"): nosniff, AnyHashable("Expires"): 0, AnyHashable("Transfer-Encoding"): Identity, AnyHashable("Connection"): keep-alive, AnyHashable("Date"): Sun, 09 Feb 2025 08:17:03 GMT, AnyHashable("Pragma"): no-cache, AnyHashable("Keep-Alive"): timeout=60, AnyHashable("X-Frame-Options"): DENY, AnyHashable("Cache-Control"): no-cache, no-store, max-age=0, must-revalidate, AnyHashable("X-XSS-Protection"): 0]
✅ [DEBUG] 성공적으로 디코딩됨: ApiResponse<PostResponse>(isSuccess: true, code: "COMMON200", message: "성공입니다.", result: Optional(Duckmelang.PostResponse(postList: [], listSize: 0, totalPage: 0, totalElements: 0, isFirst: false, isLast: true)))

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
